### PR TITLE
FCB: Rename should support asterisk wildcards

### DIFF
--- a/kernel/fcbfns.c
+++ b/kernel/fcbfns.c
@@ -502,12 +502,38 @@ UBYTE FcbDelete(xfcb FAR * lpXfcb)
   return result;
 }
 
+static void FcbExpandAsterisks(char *p)
+{
+  int i, afound;
+
+  // Filename
+  for (i = 0, afound = 0; i < 8; i++) {
+    if (p[i] == '*' || afound) {
+      p[i] = '?';
+      afound = 1;
+    }
+  }
+
+  // Extension
+  for (i = 8, afound = 0; i < 11; i++) {
+    if (p[i] == '*' || afound) {
+      p[i] = '?';
+      afound = 1;
+    }
+  }
+}
+
 UBYTE FcbRename(xfcb FAR * lpXfcb)
 {
   rfcb FAR *lpRenameFcb;
   COUNT FcbDrive;
   UBYTE result = FCB_SUCCESS;
   void FAR *lpOldDta = dta;
+
+  /* DOS 3.0+ allows * wildcards for rename */
+  rfcb FAR *trfcb = (rfcb FAR *)lpXfcb;
+  FcbExpandAsterisks(trfcb->renOldName);
+  FcbExpandAsterisks(trfcb->renNewName);
 
   /* Build a traditional DOS file name                            */
   lpRenameFcb = (rfcb FAR *) CommonFcbInit(lpXfcb, SecPathName, &FcbDrive);


### PR DESCRIPTION
Since DOS 3.0 the FCB rename function int21/17 supports asterisk
wildcards. Add a function to expand the '*' into '?' to fill the
remaining buffer.

This changes FDPP to behave the same as PC-DOS, MS-DOS and DR-DOS for both FAT and redirector based filesystems.

Style questions:
- I may need to add something similar for int21/13 Delete, do you prefer squashing with this into a single patch?
- Do you prefer four calls to `FcbExpandAsterisks()`,  one with duplication inside the function, or two calls to function that handles filename and extension? 
