### PR TITLE
share: Check share table before delete/rename

### DIFF
--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -1156,10 +1156,13 @@ COUNT DosDelete(const char FAR * path, int attrib)
   if (result & IS_DEVICE)
     return DE_FILENOTFND;
 
+  if (IsShareInstalled(TRUE) && share_is_file_open(PriPathName))
+    return DE_ACCESS;
+
   return dos_delete(PriPathName, attrib);
 }
 
-COUNT DosRenameTrue(const char * path1, const char * path2, int attrib)
+COUNT DosRenameTrue(const char FAR * path1, const char FAR * path2, int attrib)
 {
   if (path1[0] != path2[0])
   {
@@ -1167,6 +1170,9 @@ COUNT DosRenameTrue(const char * path1, const char * path2, int attrib)
   }
   if (FP_OFF(current_ldt) == 0xFFFF || (current_ldt->cdsFlags & CDSNETWDRV))
     return network_redirector(REM_RENAME);
+
+  if (IsShareInstalled(TRUE) && share_is_file_open(path1))
+    return DE_ACCESS;
 
   return dos_rename(path1, path2, attrib);
 }

--- a/kernel/int2f.asm
+++ b/kernel/int2f.asm
@@ -322,6 +322,25 @@ SHARE_LOCK_UNLOCK:
 		mov	ax,0x10a4
 		jmp	short share_common
 
+;           DOS calls this to see if share already has the file marked as open.
+;           Returns:
+;             1 if open
+;             0 if not
+; STATIC WORD share_is_file_open(const char FAR * filename) /* pointer to fully qualified filename */
+		global SHARE_IS_FILE_OPEN
+SHARE_IS_FILE_OPEN:
+		mov	si, ds
+		mov	es, si		; save ds
+		pop	ax		; save return address
+		pop	si		; filename
+		pop	ds		; SEG filename
+		push	ax		; restore return address
+		mov	ax, 0x10a6
+		int	0x2f	     	; returns ax
+		mov	si, es		; restore ds
+		mov	ds, si
+		ret
+
 ; Int 2F Multipurpose Remote System Calls
 ;
 ; added by James Tabor jimtabor@infohwy.com

--- a/kernel/proto.h
+++ b/kernel/proto.h
@@ -110,7 +110,7 @@ COUNT DosSetFattr(__FAR(const char) name, UWORD attrp);
 UBYTE DosSelectDrv(UBYTE drv);
 COUNT DosDelete(__FAR(const char) path, int attrib);
 COUNT DosRename(__FAR(const char) path1,__FAR(const char) path2);
-COUNT DosRenameTrue(const char * path1, const char * path2, int attrib);
+COUNT DosRenameTrue(__FAR(const char) path1, __FAR(const char) path2, int attrib);
 COUNT DosMkRmdir(__FAR(const char) dir, int action);
 __FAR(struct dhdr)IsDevice(__XFAR(const char) FileName);
 BOOL IsShareInstalled(BOOL recheck);
@@ -488,6 +488,12 @@ WORD ASMPASCAL share_access_check(unsigned short pspseg, WORD fileno, UDWORD ofs
            If the return value is non-zero, it is the negated error
            return code for the DOS 0x5c call. */
 WORD ASMPASCAL share_lock_unlock(unsigned short pspseg, WORD fileno, UDWORD ofs, UDWORD len, WORD unlock);       /* one to unlock; zero to lock */
+
+        /* DOS calls this to see if share already has the file marked as open.
+           Returns:
+             1 if open
+             0 if not */
+WORD ASMPASCAL share_is_file_open(__FAR(const char) filename);
 
 unsigned char ASMPASCAL share_check(void);
 


### PR DESCRIPTION
Outwardly behaves the same way as MS-DOS 6.22 and so passes the test in https://github.com/dosemu2/dosemu2/pull/1133

Slightly suboptimal in that if deletion is possible it adds to the share table, then immediately removes it, but doing anything else would require a new function to scan the share table without adding to it.