### PR TITLE
FATFS: rmdir of read only directories is valid

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -472,8 +472,9 @@ COUNT dos_rmdir(const char * path)
     return DE_PATHNOTFND;
 
   /* Directories may have attributes, but if other than 'archive'      */
-  /* then do not allow (RDONLY|SYSTEM|HIDDEN) directory to be deleted. */
-  if (fnp->f_dir.dir_attrib & ~(D_DIR |D_ARCHIVE))
+  /* or 'read only' then deny i.e. do not allow (SYSTEM|HIDDEN)        */
+  /* directory to be deleted.                                          */
+  if (fnp->f_dir.dir_attrib & ~(D_DIR | D_RDONLY | D_ARCHIVE))
     return DE_ACCESS;
 
   dir_read(fnp);


### PR DESCRIPTION
[fixes #161] After comparison with DR-DOS 7.01 and MS-DOS 6.22 it can
be seen that rmdir of a directory having the _A_RDONLY bit set should
succeed. This patch makes that change.

After applying the test result is now.
~~~
$ python test/test_dos.py test_fat_sfn_perms_check_rmdir
Test DR-DOS-7.01 FAT SFN Permission check on rmdir                               ... ok (  2.44s)
Test FR-DOS-1.20 FAT SFN Permission check on rmdir                               ... FAIL
Test MS-DOS-6.22 FAT SFN Permission check on rmdir                               ... ok (  2.25s)
Test PP-DOS-GIT FAT SFN Permission check on rmdir                                ... ok (  1.92s)

======================================================================
FAIL: Test FR-DOS-1.20 FAT SFN Permission check on rmdir                              
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_dos.py", line 4863, in test_fat_sfn_perms_check_rmdir
    perms_check_rmdir(self, "FAT", "SFN")
  File "/clients/common/dosemu2.git/test/func_perms_check_rmdir.py", line 81, in perms_check_rmdir
    self.assertNotIn("FAIL:", results)
AssertionError: 'FAIL:' unexpectedly found in "testit.bat\r\nC:\\>d:\r\nD:\\>set LFN=n\r\nD:\\>c:\\defattr\r\nINFO: Mkdir = 'DIR_RO', err=0\r\nINFO: Getfattr attr=0x11\r\nFAIL: Rmdir failed, err=-1\r\nD:\\>"
Further info in file 'test_dos.FRDOS120TestCase.test_fat_sfn_perms_check_rmdir.log'
Further info in file 'test_dos.FRDOS120TestCase.test_fat_sfn_perms_check_rmdir.xpt'

----------------------------------------------------------------------
Ran 4 tests in 8.253s

FAILED (failures=1)
~~~