### PR TITLE
Test: Avoid building on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 
 dist:  focal
 
+if: type = cron
+
 before_install:
   - ./ci_prereq.sh
 


### PR DESCRIPTION
Since we don't actually test anything with CI on FDPP, it's pointless
wasting Travis credits just to check the build as we can do that with
Github Actions. Disable the Travis test by only triggering on cron
events (there are none configured).