### PR TITLE
make: Avoid building thunk_gen with C++

### DIFF
--- a/fdpp/parsers/makefile
+++ b/fdpp/parsers/makefile
@@ -4,7 +4,7 @@ srcdir ?= $(CURDIR)
 include $(srcdir)/../clang.mak
 
 thunk_gen: lex.yy.c thunk_gen.tab.c
-	$(CLC) -g -o $@ $^
+	clang -g -o $@ $^
 
 thunk_gen.tab.c: $(srcdir)/thunk_gen.y
 	bison -d $^


### PR DESCRIPTION
Removes the following warnings:
  lex /clients/common/fdpp.git/fdpp/parsers/thunk_gen.l
  bison -d /clients/common/fdpp.git/fdpp/parsers/thunk_gen.y
  clang++ -g -o thunk_gen lex.yy.c thunk_gen.tab.c
  clang: warning: treating 'c' input as 'c++' when in C++ mode, this
  behavior is deprecated [-Wdeprecated]
  clang: warning: treating 'c' input as 'c++' when in C++ mode, this
  behavior is deprecated [-Wdeprecated]