### PR TITLE
fatdir: clean up swap_deleted() logic [#202]

### DIFF
--- a/hdr/fat.h
+++ b/hdr/fat.h
@@ -110,7 +110,7 @@ struct dirent {
   char dir_name[FNAME_SIZE + FEXT_SIZE];   /* Filename + extension in FCB format */
   UBYTE dir_attrib;             /* File Attribute               */
   UBYTE dir_case;               /* File case                    */
-  UBYTE dir_crtimems;           /* Milliseconds                 */
+  UBYTE dir_crtimems_or_fchar;  /* Create time (msecs) or first name char */
   UWORD dir_crtime;             /* Creation time                */
   UWORD dir_crdate;             /* Creation date                */
   UWORD dir_accdate;            /* Last access date             */

--- a/hdr/fat.h
+++ b/hdr/fat.h
@@ -54,8 +54,17 @@ static BYTE *fat_hRcsId =
 #define FEXT_SIZE               3
 
 /* FAT deleted flag                                                     */
-#define DELETED         '\x5'    /* if first char, delete file   */
+#define DFLG_DELETED      1      /* indicate the file is deleted */
+#define DFLG_DELETE_PEND  2      /* file deletion is pending     */
+#define SET_DELETED(fnp)  ((fnp)->d_flags |= DFLG_DELETE_PEND)
+#define SET_RDELETED(fnp) do { \
+    ((fnp)->d_flags |= DFLG_DELETED); \
+    ((fnp)->d_flags &= ~DFLG_DELETE_PEND); \
+} while (0)
+#define DELETED(fnp)      ((fnp)->d_flags & DFLG_DELETED)
+#define DELETE_PEND(fnp)  ((fnp)->d_flags & DFLG_DELETE_PEND)
 #define EXT_DELETED     '\xe5'   /* external deleted flag */
+#define SUBSTED_E5      '\x5'    /* replacement for E5 char */
 
 /* Test for 16 bit or 12 bit FAT                                        */
 #define SIZEOF_CLST16   2

--- a/hdr/fnode.h
+++ b/hdr/fnode.h
@@ -41,6 +41,7 @@ struct f_node {
   dmatch *f_dmp;                /* this file's dir match        */
 //  SYM_MEMB(f_node, struct dirent, f_dir);          /* this file's dir entry image  */
   struct dirent f_dir;          /* this file's dir entry image  */
+  UWORD d_flags;
 
   ULONG f_dirsector;            /* the sector containing dir entry*/
   UBYTE f_diridx;               /* offset/32 of dir entry in sec*/

--- a/kernel/fatdir.c
+++ b/kernel/fatdir.c
@@ -143,7 +143,20 @@ STATIC void swap_deleted_rd(f_node_ptr fnp)
   char *name = fnp->f_dir.dir_name;
 
   if (name[0] == EXT_DELETED)
+  {
+    char c;
+
     SET_RDELETED(fnp);
+    switch ((c = fnp->f_dir.dir_crtimems_or_fchar))
+    {
+      case EXT_DELETED:    // no undelete
+      case '\0':           // undelete w/o back-up char
+        break;
+      default:
+        name[0] = c;       // may be '\x5', then converted below
+        break;
+    }
+  }
   if (name[0] == SUBSTED_E5)
     name[0] = EXT_DELETED;
 }
@@ -157,7 +170,10 @@ STATIC BOOL swap_deleted_wr(f_node_ptr fnp)
   if (name[0] == EXT_DELETED)
     name[0] = SUBSTED_E5;
   if (DELETE_PEND(fnp))
+  {
+    fnp->f_dir.dir_crtimems_or_fchar = name[0];
     name[0] = EXT_DELETED;
+  }
   return TRUE;
 }
 
@@ -166,7 +182,10 @@ STATIC void unswap_deleted_wr(f_node_ptr fnp)
   char *name = fnp->f_dir.dir_name;
 
   if (DELETE_PEND(fnp))
+  {
     SET_RDELETED(fnp);
+    name[0] = fnp->f_dir.dir_crtimems_or_fchar;
+  }
   if (name[0] == SUBSTED_E5)
     name[0] = EXT_DELETED;
 }


### PR DESCRIPTION
Use '\x1' for deleted indicator to make logic less confusing.