### PR TITLE
CI: Update to use current builtin actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Package install
       run: ./ci_prereq.sh


### PR DESCRIPTION
Older actions use deprecated node16, so update to avoid the warning.