### PR TITLE
bpb: Convert sz string to 83 for volume name

### DIFF
--- a/kernel/dsk.c
+++ b/kernel/dsk.c
@@ -93,7 +93,7 @@ COUNT writelabelBPB(char drive, const char *name)
 
   /* store volume name */
   fs = (struct FS_info *)&DiskTransferBuffer[offset];
-  memcpy(&fs->volume[0], name, 11);
+  ConvertNameSZToName83(fs->volume, name);
 
   ret = RWzero(pddt, LBA_WRITE);
   if (ret != 0)


### PR DESCRIPTION
It passed the tests before only because I used a test string of 8 characters, whereas a longer one would contain the dot, and shorter padding spaces.