### PR TITLE
move to libdir

### DIFF
--- a/ci_setup_test.sh
+++ b/ci_setup_test.sh
@@ -40,7 +40,7 @@ fi
 
   CC=clang ./default-configure -d \
     --prefix=${DIR_ROOT}/${DIR_INSTALLED_FDPP} \
-    --with-fdpp-lib-dir=${DIR_ROOT}/${DIR_INSTALLED_FDPP}/lib/fdpp \
+    --with-fdpp-lib-dir=${DIR_ROOT}/${DIR_INSTALLED_FDPP}/lib \
     --with-fdpp-include-dir=${DIR_ROOT}/${DIR_INSTALLED_FDPP}/include \
     --with-fdpp-pkgconf-dir=${DIR_ROOT}/${DIR_INSTALLED_FDPP}/lib/pkgconfig
   make

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends:
     debhelper (>= 9~)
 Homepage: https://github.com/dosemu2/fdpp
 
-Package: fdpp
+Package: libfdpp35
 Architecture: any
 Section: otherosfs
 Depends: ${misc:Depends}, ${shlibs:Depends}
@@ -27,10 +27,17 @@ Description: 64-bit DOS core
  fdpp is a 64-bit DOS core.
  It is based on a FreeDOS kernel ported to modern C++.
 
+Package: libfdldr35
+Architecture: any
+Section: otherosfs
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: 64-bit DOS core
+ fdpp kernel loader.
+
 Package: fdpp-dev
 Architecture: any
 Section: libdevel
 Priority: optional
-Depends: fdpp (= ${binary:Version}), ${misc:Depends}
+Depends: libfdpp35 (= ${binary:Version}), libfdldr35 (= ${binary:Version}), ${misc:Depends}
 Description: fdpp development headers
  This package contains headers for fdpp usage.

--- a/debian/fdpp-dev.install
+++ b/debian/fdpp-dev.install
@@ -1,3 +1,3 @@
 usr/lib/*/pkgconfig/fdpp.pc
-usr/lib/fdpp/*.so
+usr/lib/*.so
 usr/include/fdpp

--- a/debian/fdpp-dev.install
+++ b/debian/fdpp-dev.install
@@ -1,3 +1,3 @@
 usr/lib/*/pkgconfig/fdpp.pc
-usr/lib/*.so
+usr/lib/*/*.so
 usr/include/fdpp

--- a/debian/fdpp.install
+++ b/debian/fdpp.install
@@ -1,2 +1,0 @@
-usr/lib/*.so.*
-usr/share/fdpp/*

--- a/debian/fdpp.install
+++ b/debian/fdpp.install
@@ -1,2 +1,2 @@
-usr/lib/fdpp/*.so.*
+usr/lib/*.so.*
 usr/share/fdpp/*

--- a/debian/fdpp.lintian-overrides
+++ b/debian/fdpp.lintian-overrides
@@ -1,4 +1,0 @@
-fdpp binary: arch-dependent-file-in-usr-share [usr/share/fdpp/fdppkrnl.elf]
-fdpp binary: statically-linked-binary [usr/share/fdpp/fdppkrnl.elf]
-fdpp binary: unstripped-binary-or-object [usr/share/fdpp/fdppkrnl.elf]
-fdpp binary: binary-from-other-architecture [usr/share/fdpp/fdppkrnl.elf]

--- a/debian/libfdldr35.install
+++ b/debian/libfdldr35.install
@@ -1,0 +1,2 @@
+usr/lib/*/libfdldr*.so.*
+usr/share/fdpp/*

--- a/debian/libfdldr35.lintian-overrides
+++ b/debian/libfdldr35.lintian-overrides
@@ -1,0 +1,4 @@
+libfdldr35 binary: arch-dependent-file-in-usr-share [usr/share/fdpp/fdppkrnl.elf]
+libfdldr35 binary: statically-linked-binary [usr/share/fdpp/fdppkrnl.elf]
+libfdldr35 binary: unstripped-binary-or-object [usr/share/fdpp/fdppkrnl.elf]
+libfdldr35 binary: binary-from-other-architecture [usr/share/fdpp/fdppkrnl.elf]

--- a/debian/libfdpp35.install
+++ b/debian/libfdpp35.install
@@ -1,0 +1,1 @@
+usr/lib/*/libfdpp*.so.*

--- a/debian/rules
+++ b/debian/rules
@@ -4,8 +4,8 @@
 	dh $@ --parallel --builddirectory=build
 
 override_dh_auto_build:
-	dh_auto_build $@ -- prefix=/usr
+	dh_auto_build $@ -- prefix=/usr libdir=/usr/lib/${DEB_HOST_MULTIARCH}
 
 override_dh_auto_install:
-	dh_auto_install $@ -- prefix=/usr \
+	dh_auto_install $@ -- prefix=/usr libdir=/usr/lib/${DEB_HOST_MULTIARCH} \
 		pkgconfdir=/usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig

--- a/fdpp.spec.rpkg
+++ b/fdpp.spec.rpkg
@@ -46,7 +46,7 @@ meson install -C build --destdir %{buildroot}
 
 %files
 %defattr(-,root,root)
-%{_libdir}/fdpp/*.so.*
+%{_libdir}/*.so.*
 %{_datadir}/fdpp
 
 %package devel
@@ -58,7 +58,7 @@ This package contains headers for fdpp usage.
 %files devel
 %defattr(-,root,root)
 %{_libdir}/pkgconfig/fdpp.pc
-%{_libdir}/fdpp/*.so
+%{_libdir}/*.so
 %{_includedir}/fdpp
 
 %changelog

--- a/fdpp/fdpp.pc.in
+++ b/fdpp/fdpp.pc.in
@@ -1,7 +1,4 @@
-libdir=@LIBDIR@
-fdpplibdir=${libdir}/fdpp
-
 Name: fdpp
 Description: 64-bit DOS core
 Version: @VERSION@
-Libs: -L${fdpplibdir} -lfdpp -lfdldr
+Libs: -lfdpp -lfdldr

--- a/fdpp/loader/makefile
+++ b/fdpp/loader/makefile
@@ -19,7 +19,7 @@ BVER = $(shell echo BPRM_VER | cpp -include $(PPINC)/bprm.h - | tail -n 1)
 TARGET=fdppkrnl.$(AVER).$(BVER)
 FDPPDEVL = libfdldr.so
 FDPPLIB = $(FDPPDEVL).$(AVER).$(BVER)
-LDFLAGS += -Wl,-soname=$(FDPPLIB) -L..
+LDFLAGS += -Wl,-soname=$(FDPPDEVL).$(AVER) -L..
 SOURCES = elf.c loader.c
 HEADERS = elf_priv.h
 OBJECTS = $(SOURCES:.c=.o)

--- a/fdpp/loader/meson.build
+++ b/fdpp/loader/meson.build
@@ -24,5 +24,4 @@ LIBLOADER = shared_library('fdldr', 'elf.c', 'loader.c',
   # But we trick it by having gcc as cross-compiler, and cross-linking
   # via custom_target.
 #  native: true,
-  install: true,
-  install_dir: get_option('libdir') / 'fdpp')
+  install: true)

--- a/fdpp/makefile
+++ b/fdpp/makefile
@@ -178,11 +178,11 @@ endif
 
 INSTALL ?= install
 install: $(ALL)
-	$(INSTALL) -d $(DESTDIR)$(libdir)/fdpp
-	$(INSTALL) $(FDPPLIB) $(DESTDIR)$(libdir)/fdpp
-	cp -fP $(FDPPDEVL) $(DESTDIR)$(libdir)/fdpp
-	$(INSTALL) $(LDRLIB) $(DESTDIR)$(libdir)/fdpp
-	cp -fP $(LDRDEVL) $(DESTDIR)$(libdir)/fdpp
+	$(INSTALL) -d $(DESTDIR)$(libdir)
+	$(INSTALL) $(FDPPLIB) $(DESTDIR)$(libdir)
+	cp -fP $(FDPPDEVL) $(DESTDIR)$(libdir)
+	$(INSTALL) $(LDRLIB) $(DESTDIR)$(libdir)
+	cp -fP $(LDRDEVL) $(DESTDIR)$(libdir)
 	$(INSTALL) -d $(DESTDIR)$(datadir)/fdpp
 	$(INSTALL) -m 0644 $(TARGET).elf $(DESTDIR)$(datadir)/fdpp
 	$(INSTALL) -m 0644 $(TARGET).map $(DESTDIR)$(datadir)/fdpp
@@ -196,6 +196,10 @@ uninstall:
 	$(RM) -r $(DESTDIR)$(datadir)/fdpp
 	$(RM) -r $(DESTDIR)$(pkgconfdir)/fdpp.pc
 	$(RM) -r $(DESTDIR)$(prefix)/include/fdpp
+	$(RM) -f $(DESTDIR)$(libdir)/$(FDPPDEVL)
+	$(RM) -f $(DESTDIR)$(libdir)/$(FDPPLIB)
+	$(RM) -f $(DESTDIR)$(libdir)/$(LDRDEVL)
+	$(RM) -f $(DESTDIR)$(libdir)/$(LDRLIB)
 
 $(TGZ):
 	cd $(TOP) && git archive -o $(TOP)/$(TAR) --prefix=$(PKG)/ HEAD

--- a/fdpp/makefile
+++ b/fdpp/makefile
@@ -22,7 +22,7 @@ FDPPDEVL = libfdpp.so
 FDPPLIB = $(FDPPDEVL).$(AVER).$(BVER)
 LDRDEVL = libfdldr.so
 LDRLIB = $(LDRDEVL).$(AVER).$(BVER)
-LDFLAGS += -Wl,-soname=$(FDPPLIB) -Wl,-Bsymbolic
+_LDFLAGS = -Wl,-soname=$(FDPPLIB) -Wl,-Bsymbolic
 TARGET=fdppkrnl.$(AVER).$(BVER)
 MAJ = 1
 RELVER = 10
@@ -147,7 +147,7 @@ $(GEN_CC): %.cc: $(SRC)/%.c makefile
 	$(srcdir)/parsers/mkfar.sh $< >$@
 
 $(FDPPLIB): $(OBJECTS) $(FDPP_COBJS) $(FDPP_CCOBJS) $(FDPP_CPPOBJS)
-	$(CXX_LD) -o $@ $^ $(LDFLAGS) $(LIBS)
+	$(CXX_LD) -o $@ $^ $(LDFLAGS) $(_LDFLAGS) $(LIBS)
 	@echo "Have `nm -u $@ | grep "U " | wc -l` undefined symbols"
 
 $(FDPPDEVL): | $(FDPPLIB)

--- a/fdpp/makefile
+++ b/fdpp/makefile
@@ -20,9 +20,11 @@ AVER = $(shell echo FDPP_API_VER | cpp -include $(PPINC)/thunks.h - | tail -n 1)
 BVER = $(shell echo BPRM_VER | cpp -include $(PPINC)/bprm.h - | tail -n 1)
 FDPPDEVL = libfdpp.so
 FDPPLIB = $(FDPPDEVL).$(AVER).$(BVER)
+FDPPVSO = $(FDPPDEVL).$(AVER)
 LDRDEVL = libfdldr.so
 LDRLIB = $(LDRDEVL).$(AVER).$(BVER)
-_LDFLAGS = -Wl,-soname=$(FDPPLIB) -Wl,-Bsymbolic
+LDRVSO = $(LDRDEVL).$(AVER)
+_LDFLAGS = -Wl,-soname=$(FDPPVSO) -Wl,-Bsymbolic
 TARGET=fdppkrnl.$(AVER).$(BVER)
 MAJ = 1
 RELVER = 10
@@ -43,8 +45,8 @@ CPPFLAGS += -I . -I $(FD_EXT_H) -I $(SRC) -I $(srcdir)
 
 #               *Explicit Rules*
 
-ALL = $(FDPPLIB) $(FDPPDEVL) $(LDRLIB) $(LDRDEVL) $(TARGET).elf $(TARGET).map \
-    $(GEN_EXT)
+ALL = $(FDPPLIB) $(FDPPDEVL) $(LDRLIB) $(LDRDEVL) $(FDPPVSO) $(LDRVSO) \
+    $(TARGET).elf $(TARGET).map $(GEN_EXT)
 
 all: $(ALL)
 
@@ -150,10 +152,10 @@ $(FDPPLIB): $(OBJECTS) $(FDPP_COBJS) $(FDPP_CCOBJS) $(FDPP_CPPOBJS)
 	$(CXX_LD) -o $@ $^ $(LDFLAGS) $(_LDFLAGS) $(LIBS)
 	@echo "Have `nm -u $@ | grep "U " | wc -l` undefined symbols"
 
-$(FDPPDEVL): | $(FDPPLIB)
+$(FDPPDEVL) $(FDPPVSO): | $(FDPPLIB)
 	ln -sf $(FDPPLIB) $@
 
-$(LDRDEVL): | $(LDRLIB)
+$(LDRDEVL) $(LDRVSO): | $(LDRLIB)
 	ln -sf $(LDRLIB) $@
 
 # we have custom PDS
@@ -181,8 +183,10 @@ install: $(ALL)
 	$(INSTALL) -d $(DESTDIR)$(libdir)
 	$(INSTALL) $(FDPPLIB) $(DESTDIR)$(libdir)
 	cp -fP $(FDPPDEVL) $(DESTDIR)$(libdir)
+	cp -fP $(FDPPVSO) $(DESTDIR)$(libdir)
 	$(INSTALL) $(LDRLIB) $(DESTDIR)$(libdir)
 	cp -fP $(LDRDEVL) $(DESTDIR)$(libdir)
+	cp -fP $(LDRVSO) $(DESTDIR)$(libdir)
 	$(INSTALL) -d $(DESTDIR)$(datadir)/fdpp
 	$(INSTALL) -m 0644 $(TARGET).elf $(DESTDIR)$(datadir)/fdpp
 	$(INSTALL) -m 0644 $(TARGET).map $(DESTDIR)$(datadir)/fdpp
@@ -197,8 +201,10 @@ uninstall:
 	$(RM) -r $(DESTDIR)$(pkgconfdir)/fdpp.pc
 	$(RM) -r $(DESTDIR)$(prefix)/include/fdpp
 	$(RM) -f $(DESTDIR)$(libdir)/$(FDPPDEVL)
+	$(RM) -f $(DESTDIR)$(libdir)/$(FDPPVSO)
 	$(RM) -f $(DESTDIR)$(libdir)/$(FDPPLIB)
 	$(RM) -f $(DESTDIR)$(libdir)/$(LDRDEVL)
+	$(RM) -f $(DESTDIR)$(libdir)/$(LDRVSO)
 	$(RM) -f $(DESTDIR)$(libdir)/$(LDRLIB)
 
 $(TGZ):

--- a/fdpp/meson.build
+++ b/fdpp/meson.build
@@ -184,5 +184,4 @@ LIBFDPP = shared_library('fdpp', [ccfiles, ppccf, FDPP_CCFILES, CPPFILES],
   sources: [gad, pac, pap, tc, ta],
   cpp_args: CXX_ARGS,
   link_args: ['-Wl,-Bsymbolic', LD_ARGS],
-  install: true,
-  install_dir: get_option('libdir') / 'fdpp')
+  install: true)

--- a/hdr/version.h
+++ b/hdr/version.h
@@ -48,6 +48,6 @@
 #ifndef CMA
 #define CMA
 #endif
-#define KVS(v) "FDPP kernel " CMA #v CMA " (compiled " CMA __DATE__ CMA ")"
+#define KVS(v) "FDPP kernel " CMA #v
 #define xKVS(v) KVS(v)
 #define KERNEL_VERSION_STRING xKVS(KERNEL_VERSION)


### PR DESCRIPTION
Instead of lib/fdpp/*.so we'll now have lib/*.so to be reachable by ldconfig.