### PR TITLE
deb: remove clang and build-essentials

### DIFF
--- a/ci_prereq.sh
+++ b/ci_prereq.sh
@@ -4,8 +4,8 @@ sudo apt-get update
 sudo apt install -y \
   devscripts \
   equivs \
-  git
+  git \
+  clang
 
-sudo add-apt-repository ppa:stsp-0/nasm-segelf
 sudo add-apt-repository ppa:stsp-0/thunk-gen
 mk-build-deps --install --root-cmd sudo

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,8 @@ Priority: optional
 Maintainer: Stas Sergeev <stsp@users.sourceforge.net>
 Standards-Version: 3.9.7
 Build-Depends:
-    make,
-    sed,
-    bash,
-    clang,
     nasm,
-    binutils,
     binutils-x86-64-linux-gnu,
-    coreutils,
     libelf-dev,
     thunk-gen (>= 1.9~),
     git,


### PR DESCRIPTION
Instead add clang to ci_prereq.sh as its still used on CI.